### PR TITLE
Added minification support for JavaScript files

### DIFF
--- a/lib/js.coffee
+++ b/lib/js.coffee
@@ -1,20 +1,22 @@
 Bundle = require './bundle'
+UglifyJS = require 'uglify-js'
 class Js extends Bundle
   constructor: (@options) ->
     @fileExtension = '.js'
     super
 
   minify: (code) ->
-    # Haven't found any nice minifier
-    # that doesn't break the code
-    return code
+    ast = UglifyJS.parser.parse code # parse code and get the initial AST
+    ast = UglifyJS.uglify.ast_mangle ast # get a new AST with mangled names
+    ast = UglifyJS.uglify.ast_squeeze ast # get an AST with compression optimizations
+    UglifyJS.uglify.gen_code ast # compressed code here
 
   render: (namespace) ->
     js = ''
     for file in @files
       if file.namespace == namespace
         js += "<script src='#{file.url}' type='text/javascript'></script>"
-    return js
+    js
 
   _convertFilename: (filename) ->
     splitted = filename.split('.')


### PR DESCRIPTION
Added support for minification on javascript files.

Also in Coffee-Script there is no need to have `return` statement since coffee don't produce any void functions, even transparently they return always something so this:

```
 method = (a) ->
    return a;
```

is same with this:

```
method = (a) ->
    a
```

you could emulate a `void` method like this:

```
method = (a) ->
    a.action() # or what ever here...
    null #return null to emulate a void method
```
