### PR TITLE
Add minify options to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ var BundleUp = require('bundle-up');
 BundleUp(app, __dirname + '/assets', {
   staticRoot: __dirname + '/public/',
   staticUrlRoot:'/',
-  bundle:true
+  bundle:true,
+  minifyCss: true,
+  minifyJs: true
 });
 
 // To actually serve the files a static file


### PR DESCRIPTION
BundleUp support js and css minification but there was no word about that in the README. I just updated the example to include minifyJs and minifyCss options.
