### PR TITLE
Fix for windows assets path

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -29,6 +29,7 @@ normalizeUrl = (url) ->
   protocol = url.match(/^(http|https):\/\//)?[0]
   protocol = '' unless protocol?
   url = url.replace(protocol, '')
+  url = url.replace('\\', '/')
   url = url.replace('//', '/')
   return protocol + url
 

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -29,7 +29,6 @@ normalizeUrl = (url) ->
   protocol = url.match(/^(http|https):\/\//)?[0]
   protocol = '' unless protocol?
   url = url.replace(protocol, '')
-  url = url.replace('\\', '/')
   url = url.replace('//', '/')
   return protocol + url
 


### PR DESCRIPTION
When bundle-up is called from Windows, it uses the file path to generate the compiled assets url, resulting in things like "/\generated\bundle\asdfg.css".

This little patch fixes that.
