### PR TITLE
Integrated with UglifyJS v2

### DIFF
--- a/lib/js.coffee
+++ b/lib/js.coffee
@@ -7,11 +7,7 @@ class Js extends Bundle
 
   minify: (code) ->
     return code unless @options.minifyJs
-
-    ast = UglifyJS.parser.parse code # parse code and get the initial AST
-    ast = UglifyJS.uglify.ast_mangle ast # get a new AST with mangled names
-    ast = UglifyJS.uglify.ast_squeeze ast # get an AST with compression optimizations
-    UglifyJS.uglify.gen_code ast # compressed code here
+    UglifyJS.minify(code, { fromString: true }).code # Minify with UglifyJS (v2)
 
   render: (namespace) ->
     js = ''

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     , "async": ">= 0.1.15"
     , "stylus": ">= 0.19.0"
     , "mkdirp": ">= 0.0.7"
-    , "uglify-js" : ">= 1.2.5"
+    , "uglify-js" : ">= 2.2.0"
   },
   "devDependencies": {
       "mocha": ">= 0.11.0"

--- a/test/bundle_spec.coffee
+++ b/test/bundle_spec.coffee
@@ -10,10 +10,22 @@ describe 'bundle:true', ->
   beforeEach ->
     helper.beforeEach()
     @app = express.createServer()
+    
+    # Bundle once without minifying and then once _with_ minifying:
+    
     @bundle = BundleUp @app, __dirname + "/files/assets.coffee",
       staticRoot: __dirname + "/files/public/",
       staticUrlRoot:"/",
-      bundle:true
+      bundle:true,
+      minifyJs:false,
+      minifyCss:false
+      
+    @bundle = BundleUp @app, __dirname + "/files/assets.coffee",
+      staticRoot: __dirname + "/files/public/",
+      staticUrlRoot:"/",
+      bundle:true,
+      minifyJs:true,
+      minifyCss:true
 
   describe 'individual files', ->
     it 'should create coffee/1.js', (done) ->


### PR DESCRIPTION
Howdy,

As discussed, I modified the Js module (in `lib/js.coffee`) to work with the new (and simplified) UglifyJS v2 API. All seems to work well and swell.

NOTES:
I noticed the tests weren't "exercising" the minifyJs option in the first place. Rather than modifying them to _always_ use `minifyJs:true` I opted for doing both. The simplest way to achieve that was to add a 2nd call to `BundleUp()` – with `minifyJs:true` – inside the tests' `beforeEach()` method (in `bundle_spec.coffee`). That may not be the safest way, but hopefully it's still acceptable.

Let me know if you'd like me to modify/add anything.

Cheers!
- Amit
