### PR TITLE
Adding CSS `url()` rewriting

### DIFF
--- a/lib/css.coffee
+++ b/lib/css.coffee
@@ -1,13 +1,22 @@
 csso = require 'csso'
 Bundle = require './bundle'
+path = require 'path'
+
 class Css extends Bundle
   constructor: (@options) ->
     @fileExtension = '.css'
     super
 
+  _rewriteUrls: (code, relativeURL) ->
+    code.replace /url\(['"]?([^\)]*)['"]?\)/g, (match, $1) ->
+      resUrl = path.normalize(path.join(relativeURL, $1))
+      return "url('#{resUrl}')"
+
+  _needsUrlRewrite: ->
+    @options.bundle == true
+
   minify: (code) ->
     return code unless @options.minifyCss
-
     csso.justDoIt(code)
 
   render: (namespace) ->

--- a/lib/css.coffee
+++ b/lib/css.coffee
@@ -8,7 +8,7 @@ class Css extends Bundle
     super
 
   _rewriteUrls: (code, relativeURL) ->
-    code.replace /url\(['"]?([^\)]*)['"]?\)/g, (match, $1) ->
+    code.replace /url\(['"]?([^\)"']*)['"]?\)/g, (match, $1) ->
       resUrl = path.normalize(path.join(relativeURL, $1))
       return "url('#{resUrl}')"
 

--- a/lib/css.coffee
+++ b/lib/css.coffee
@@ -8,7 +8,7 @@ class Css extends Bundle
     super
 
   _rewriteUrls: (code, relativeURL) ->
-    code.replace /url\(['"]?([^\)"']*)['"]?\)/g, (match, $1) ->
+    code.replace /url\(['"]?([^\)"'\/][^\)"']*)['"]?\)/g, (match, $1) ->
       resUrl = path.normalize(path.join(relativeURL, $1))
       return "url('#{resUrl}')"
 

--- a/test/bundle_spec.coffee
+++ b/test/bundle_spec.coffee
@@ -88,12 +88,13 @@ describe 'CSS URL Rewriting', ->
       minifyJs: false,
       minifyCss: false
 
-  it 'Bundled CSS should have their URLs rewritten', (done) ->
+  it 'Bundled CSS should have their URLs rewritten (except for the ones starting with `/`)', (done) ->
     fs.readFile @bundle.css.files[0].file, (err, data) ->
       data = data.toString()
       expect(data.match(/'\.\.\/css\/relative\/path\/to\/file1\.jpg'/).length).to.equal(1)
       expect(data.match(/'\.\.\/css\/relative\/path\/to\/file2\.jpg'/).length).to.equal(1)
       expect(data.match(/'\.\.\/css\/relative\/path\/to\/file3\.jpg'/).length).to.equal(1)
+      expect(data.match(/'\/absolute\/path\/to\/file4\.jpg'/).length).to.equal(1)
       done()
 
   it 'Non-bundled CSS should have their URLs intact', (done) ->

--- a/test/files/css/relative.css
+++ b/test/files/css/relative.css
@@ -1,0 +1,11 @@
+body {
+    background: url('relative/path/to/file1.jpg');
+}
+
+div#main {
+    background: url("relative/path/to/file2.jpg");
+}
+
+div.menu {
+    background: url(relative/path/to/file3.jpg);
+}

--- a/test/files/css/relative.css
+++ b/test/files/css/relative.css
@@ -9,3 +9,7 @@ div#main {
 div.menu {
     background: url(relative/path/to/file3.jpg);
 }
+
+div.menu2 {
+    background: url('/absolute/path/to/file4.jpg');
+}

--- a/test/files/relative.coffee
+++ b/test/files/relative.coffee
@@ -1,0 +1,3 @@
+module.exports = (assets) ->
+  assets.root = __dirname
+  assets.addCss('/css/relative.css')


### PR DESCRIPTION
Hi there!

I was having some problems with `url()` statements in minified/bundled CSS files containing relative URLs. So, I added URL rewriting capability to Bundle up. I've played with it a bit and it seems to work just fine. The unit tests seem to be OK too.

I've also added a `generatedDir` config option, just because it seemed right :) I hope it's OK with you.

Could we have this in the official release? I tried to carefully check my code since I'm quite new to CoffeeScript. So, feel free to correct it.

Thanks!
