### PR TITLE
Support for SASS compiling

### DIFF
--- a/lib/compiler.coffee
+++ b/lib/compiler.coffee
@@ -21,6 +21,11 @@ exports.compile = compile = (compilers, content, file, cb) ->
       return cb(null, compilers.css(content))
     when 'js'
       return cb(null, compilers.js(content))
+    when 'scss'
+      return compilers.sass content, (err, result) ->
+        if err?
+          console.log err.message
+        return cb(null, result)
 
 exports.compileFile =  (compilers, file, cb) ->
   content = fs.readFileSync(file, 'utf-8')

--- a/lib/css.coffee
+++ b/lib/css.coffee
@@ -1,13 +1,22 @@
 csso = require 'csso'
 Bundle = require './bundle'
+path = require 'path'
+
 class Css extends Bundle
   constructor: (@options) ->
     @fileExtension = '.css'
     super
 
+  _rewriteUrls: (code, relativeURL) ->
+    code.replace /url\(['"]?([^\)]*)['"]?\)/g, (match, $1) ->
+      resUrl = path.normalize(path.join(relativeURL, $1))
+      return "url('#{resUrl}')"
+
+  _needsUrlRewrite: ->
+    @options.bundle == true
+
   minify: (code) ->
     return code unless @options.minifyCss
-
     csso.justDoIt(code)
 
   render: (namespace) ->

--- a/lib/css.coffee
+++ b/lib/css.coffee
@@ -8,7 +8,7 @@ class Css extends Bundle
     super
 
   _rewriteUrls: (code, relativeURL) ->
-    code.replace /url\(['"]?([^\)]*)['"]?\)/g, (match, $1) ->
+    code.replace /url\(['"]?([^\)"']*)['"]?\)/g, (match, $1) ->
       resUrl = path.normalize(path.join(relativeURL, $1))
       return "url('#{resUrl}')"
 

--- a/lib/default_compilers.coffee
+++ b/lib/default_compilers.coffee
@@ -11,3 +11,6 @@ module.exports =
     return content
   css: (content) ->
     return content
+  sass: (content, callback) ->
+    sass = require 'node-sass'
+    return sass.render(content, callback)

--- a/test/files/css/relative.css
+++ b/test/files/css/relative.css
@@ -1,0 +1,11 @@
+body {
+    background: url('relative/path/to/file1.jpg');
+}
+
+div#main {
+    background: url("relative/path/to/file2.jpg");
+}
+
+div.menu {
+    background: url(relative/path/to/file3.jpg);
+}

--- a/test/files/relative.coffee
+++ b/test/files/relative.coffee
@@ -1,0 +1,3 @@
+module.exports = (assets) ->
+  assets.root = __dirname
+  assets.addCss('/css/relative.css')


### PR DESCRIPTION
Here's a small patch that adds SASS capabilities to Bundle up, in case you are interested.
I haven't added any dependencies in `package.json`, as I thought it would be better not to have it installed by default. It gets lazily imported when any SCSS files are found.
