### PR TITLE
Added support for SASS using node-sass

### DIFF
--- a/lib/bundle_up.coffee
+++ b/lib/bundle_up.coffee
@@ -13,6 +13,7 @@ class BundleUp
       options.compilers.coffee = options.compilers.coffee || compilers.coffee
       options.compilers.js = options.compilers.js || compilers.js
       options.compilers.css = options.compilers.css || compilers.css
+      options.compilers.sass = options.compilers.css || compilers.sass
 
     options.minifyCss = options.minifyCss || false
     options.minifyJs = options.minifyJs || false

--- a/lib/compiler.coffee
+++ b/lib/compiler.coffee
@@ -21,6 +21,11 @@ exports.compile = compile = (compilers, content, file, cb) ->
       return cb(null, compilers.css(content))
     when 'js'
       return cb(null, compilers.js(content))
+    when 'scss'
+      return compilers.sass content, (err, result) ->
+        if err?
+          console.log err.message
+        return cb(null, result)
 
 exports.compileFile =  (compilers, file, cb) ->
   content = fs.readFileSync(file, 'utf-8')

--- a/lib/compiler.coffee
+++ b/lib/compiler.coffee
@@ -22,10 +22,11 @@ exports.compile = compile = (compilers, content, file, cb) ->
     when 'js'
       return cb(null, compilers.js(content))
     when 'scss'
-      return compilers.sass content, (err, result) ->
+      compilers.sass(content,file).render (err, result) ->
         if err?
           console.log err.message
-        return cb(null, result)
+          result = err.message
+        return cb(err, result)
 
 exports.compileFile =  (compilers, file, cb) ->
   content = fs.readFileSync(file, 'utf-8')

--- a/lib/default_compilers.coffee
+++ b/lib/default_compilers.coffee
@@ -11,3 +11,6 @@ module.exports =
     return content
   css: (content) ->
     return content
+  sass: (content, callback) ->
+    sass = require 'node-sass'
+    return sass.render(content, callback)

--- a/lib/default_compilers.coffee
+++ b/lib/default_compilers.coffee
@@ -1,5 +1,18 @@
 coffee = require 'coffee-script'
 stylus = require 'stylus'
+path = require 'path'
+
+class SASSWrapper
+    constructor: (@content, @file) ->
+        @options = {}
+    render: (cb) =>
+        sass = require 'node-sass'
+        try
+          return cb null, sass.renderSync(@content,
+            {includePaths: [path.dirname(@file)]})
+        catch err
+          return cb err, null
+
 
 module.exports =
   stylus: (content, file) ->
@@ -11,6 +24,5 @@ module.exports =
     return content
   css: (content) ->
     return content
-  sass: (content, callback) ->
-    sass = require 'node-sass'
-    return sass.render(content, callback)
+  sass: (content, file) ->
+    return new SASSWrapper(content, file)

--- a/lib/otf_compiler.coffee
+++ b/lib/otf_compiler.coffee
@@ -2,6 +2,7 @@ fs = require 'fs'
 mkdirp = require 'mkdirp'
 async = require 'async'
 stylus = require 'stylus'
+path = require 'path'
 {compile} = require './compiler'
 
 class OnTheFlyCompiler
@@ -104,20 +105,28 @@ class OnTheFlyCompiler
         return fn()
 
   mapImports: (file, fn) ->
+    ext = path.extname(file.origFile)
     # Need to map imports for stylus files
-    if file.origFile.indexOf('.styl') > -1
+    if ext == '.styl' || ext == '.scss'
       fs.readFile file.origFile, 'utf8', (err, content) =>
         return fn(err) if err?
-        style = @compilers.stylus(content, file.origFile)
+
+        compiler = @compilers[{
+          '.styl': 'stylus',
+          '.scss': 'sass'
+          }[ext]]
+
+        style = compiler content, file.origFile
         file._imports = []
+
         paths = style.options._imports = []
         style.render (err, css) ->
-          async.forEach(paths, (path, cb) ->
-            if path.path
-              fs.stat path.path, (err, stats) ->
+          async.forEach(paths, (p, cb) ->
+            if p.path
+              fs.stat p.path, (err, stats) ->
                 return cb(err) if err?
                 file._imports.push
-                  file: path.path
+                  file: p.path
                   mtime: stats.mtime
                 cb()
             else

--- a/test/files/assets.coffee
+++ b/test/files/assets.coffee
@@ -6,3 +6,4 @@ module.exports = (assets) ->
   assets.addJs('/js/1.js')
   assets.addCss('/stylus/main.styl')
   assets.addCss('/public/print.styl')
+  assets.addCss('/sass/main.scss')

--- a/test/files/sass/main.scss
+++ b/test/files/sass/main.scss
@@ -1,0 +1,5 @@
+@import "typography";
+
+body {
+  background-color: yellow;
+}

--- a/test/files/sass/typography.scss
+++ b/test/files/sass/typography.scss
@@ -1,0 +1,3 @@
+h1 {
+  color: blue;
+}

--- a/test/otf_compiler_spec.coffee
+++ b/test/otf_compiler_spec.coffee
@@ -38,6 +38,19 @@ describe 'OnTheFlyCompiler', ->
       expect(res.body).to.equal(expected)
       done()
 
+  it 'should compile SASS files correctly', (done) ->
+    request.get 'http://localhost:1338/generated/sass/main.css', (err, res) ->
+      expected = """
+      h1 {
+        color: blue; }
+
+      body {
+        background-color: yellow; }
+
+      """
+      expect(res.body).to.equal(expected)
+      done()
+
   it 'should compile coffee files correctly', (done) ->
     request.get 'http://localhost:1338/generated/coffee/1.js', (err, res) ->
       expect(res.body).to.contain("console.log('1');")


### PR DESCRIPTION
Here's a small patch that adds SASS capabilities to Bundle up, in case you are interested.
I haven't added any dependencies in `package.json`, as I thought it would be better not to have it installed by default. It gets lazily imported when any SCSS files are found.
